### PR TITLE
[appendix/math] Fix derivative of scalar with respect to matrix

### DIFF
--- a/content/appendix/math.md
+++ b/content/appendix/math.md
@@ -136,7 +136,7 @@ and the derivative of $\bu$ with respect to $a$ is given by
 
 
 $$
-\dadb{\bu}{a} = \begin{pmatrix} \dadb{u_1}{a} \\ ... \\ \dadb{u_I}{a} \end{pmatrix} \R^I.
+\dadb{\bu}{a} = \begin{pmatrix} \dadb{u_1}{a} \\ ... \\ \dadb{u_I}{a} \end{pmatrix} \in \R^I.
 $$
 
 
@@ -160,7 +160,7 @@ and conversely the derivative of $a$ with respect to $\bX$ is given by
 
 
 $$
-\dadb{a}{\bX} =  \begin{pmatrix} \dadb{a}{X_{11}} & ... & \dadb{a}{X_{1D}} \\ & ... & \\ \dadb{a}{X_{N1}} & ... & \dadb{a}{X_{ND}} \end{pmatrix}  \in \R^{N \times D}.
+\dadb{a}{\bX} =  \begin{pmatrix} \dadb{a}{X_{11}} & ... & \dadb{a}{X_{N1}} \\ & ... & \\ \dadb{a}{X_{1D}} & ... & \dadb{a}{X_{ND}} \end{pmatrix}  \in \R^{N \times D}.
 $$
 
 


### PR DESCRIPTION
This PR aligns on using numerator layout for scalar-by-matrix derivative since numerator layout is used for all other derivatives on this page. 

If the goal was to go with a mixed layout, hence denominator layout was used for scalar-by-matrix on purpose, then feel free to disregard this PR.

Also, fixed a tiny typo of missing "belongs to" symbol in vector-by-scalar derivative.