### PR TITLE
specifying the x, y parameters

### DIFF
--- a/content/c1/code.ipynb
+++ b/content/c1/code.ipynb
@@ -83,7 +83,7 @@
    "source": [
     "sklearn_predictions = sklearn_model.predict(X_train)\n",
     "fig, ax = plt.subplots()\n",
-    "sns.scatterplot(y_train, sklearn_predictions)\n",
+    "sns.scatterplot(x=y_train, y=sklearn_predictions)\n",
     "ax.set_xlabel(r'$y$', size = 16)\n",
     "ax.set_ylabel(r'$\\hat{y}$', rotation = 0, size = 16, labelpad = 15)\n",
     "ax.set_title(r'$y$ vs. $\\hat{y}$', size = 20, pad = 10)\n",


### PR DESCRIPTION
Plot with specifying the x, y parameters.
The purpose is to solve the seaborn warning when we execute the script in GoogleColab, JupyterNotebook
```
/Users/lipuchen/venv/lib/python3.7/site-packages/seaborn/_decorators.py:43: FutureWarning: Pass the following variables as keyword args: x, y. From version 0.12, the only valid positional argument will be `data`, and passing other arguments without an explicit keyword will result in an error or misinterpretation.
  FutureWarning
```
##Before we specify the x, y parameters.
![image](https://user-images.githubusercontent.com/16587252/118072617-cb4e1080-b3dc-11eb-92f2-48cdd15a2203.png)

##After we specify the x, y parameters.
![image](https://user-images.githubusercontent.com/16587252/118072680-ec166600-b3dc-11eb-9657-0c28a9590ce1.png)

