### PR TITLE
fix beta hat expression

### DIFF
--- a/content/c1/s1/loss_minimization.md
+++ b/content/c1/s1/loss_minimization.md
@@ -211,8 +211,8 @@ We get our parameter estimates by setting this derivative equal to 0 and solving
 
 $$
 \begin{align}
-(\bX^\top \bPhi)\bbetahat &= \bX^\top \by \\\
-\bbetahat &= (\bX^\top\bX)^\top\bX^\top \by
+(\bX^\top \bX)\bbetahat &= \bX^\top \by \\\
+\bbetahat = (\bX^\top\bX)^{-1}\bX^\top \by
 \end{align}
 $$
 


### PR DESCRIPTION
1. The expression for X is mistyped as phi
2. The final result for beta hat contained a transpose instead of the inverse symbol